### PR TITLE
Update `pre-commit-hooks-dependency-sync` to `1.1.2`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
           - types-requests
           - wg-utilities==5.15.3
           - youtube-dl-nightly==2024.7.8
-          - Pillow
+          - Pillow==10.4.0
           - httpx==0.27.0
           - types-RPi.GPIO
           - ffmpeg-python==0.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - requirements.txt
 
   - repo: https://github.com/worgarside/pre-commit-hooks-dependency-sync
-    rev: 1.1.1
+    rev: 1.1.2
     hooks:
       - id: sync-additional-dependencies
 


### PR DESCRIPTION


---



- eb6416b | Update `pre-commit-hooks-dependency-sync` to `1.1.2`
- 80203e1 | [pre-commit.ci] auto fixes from pre-commit.com hooks
